### PR TITLE
Switch CI to macOS 11

### DIFF
--- a/.github/workflows/package-ci.yml
+++ b/.github/workflows/package-ci.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, macos-10.15, ubuntu-18.04]
+        os: [windows-latest, macos-11, ubuntu-18.04]
         python_version:
         - '3.6'
         - '3.7'


### PR DESCRIPTION
wpilib uses macOS 11 runners while still targeting macOS 10.14.