### PR TITLE
Better support macOS 11

### DIFF
--- a/build-wheel/action.yml
+++ b/build-wheel/action.yml
@@ -34,3 +34,9 @@ runs:
       MANYLINUX_TAG="manylinux_2_27_x86_64"
       for x in $(find ./dist -name "*$ORIG_PLAT_TAG.whl"); do mv $x ${x%$ORIG_PLAT_TAG.whl}$MANYLINUX_TAG.whl;done
       ls -l ./dist/*
+  - shell: bash
+    run: |
+      ORIG_PLAT_TAG="macosx_11_0_x86_64"
+      MAC_COMPAT_TAG="macosx_10_16_x86_64"
+      for x in $(find ./dist -name "*$ORIG_PLAT_TAG.whl"); do mv $x ${x%$ORIG_PLAT_TAG.whl}$MAC_COMPAT_TAG.whl;done
+      ls -l ./dist/*


### PR DESCRIPTION
Platform tags are weird.
For macOS 10.x versions, the platform tag will be read as 10_X.
macOS 11 complicates things.
The platform tag for macOS 11 is 11_0.
But, since a lot of tools hardcoded 10, it is also simultaneously 10_16.
Software compiled targeting a 10.X sdk will read 10_16 while software compiled targeting the 11 sdk will read 11_0.
Because of this, a platform tag of 10_16 == 11_0.

The reason our CI fails to install 11_0 wheels on macOS 11 is that the python version that setup-python installs happens to be compiled targeting macOS 10.15 so it's platform tag reports as 10_16, not 11_0.

Since macOS 11 is binary compatible with older macOSes, any wheel that is 10_9 or higher runs on macOS 11.

Note, "10_16 == 11_0" is not exactly true. The statement is actually "10_16 implies macOS 11 or higher". There is no guarantee that only macOS 11 will report 10_16, macOS 12 may also do so. 10_16 is merely the final/future 10 tag.